### PR TITLE
Fix wrong comparison from NSDateComponents that which returns a 1-bas…

### DIFF
--- a/SSFlatDatePicker.m
+++ b/SSFlatDatePicker.m
@@ -551,13 +551,13 @@
   }
   
   NSInteger currentMonthIndex = [self.scrollerMonth currentSelectedIndexPath].row;
-  if (dateComponents.month != currentMonthIndex) {
+  if (dateComponents.month-1 != currentMonthIndex) {
     [self.scrollerMonth scrollToItemAtIndexPath:[NSIndexPath indexPathForRow:dateComponents.month-1 inSection:0] atScrollPosition:UICollectionViewScrollPositionCenteredVertically animated:animated];
     [self.scrollerDay reloadData];
   }
 
   NSInteger currentDayIndex = [self.scrollerDay currentSelectedIndexPath].row;
-  if (dateComponents.day != currentDayIndex) {
+  if (dateComponents.day-1 != currentDayIndex) {
     [self.scrollerDay scrollToItemAtIndexPath:[NSIndexPath indexPathForRow:dateComponents.day-1 inSection:0] atScrollPosition:UICollectionViewScrollPositionCenteredVertically animated:animated];
   }
   


### PR DESCRIPTION
…ed date while the scroller returns a 0-based date. Ex: Setting a day that is 1 day behind the current day was not possible
